### PR TITLE
Add Dockerfile and Cloud Build for Cloud Run deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Install curl for downloading uv
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy project configuration and source code
+COPY pyproject.toml poetry.lock* langgraph.json ./
+# poetry.lock* is included in case it exists, for uv to potentially use it.
+# If only pyproject.toml is present, uv will resolve dependencies from it.
+
+COPY src/ ./src/
+
+# Install dependencies using uv
+# We install . (project dependencies) and langgraph-cli
+# Using --system to install into the global site-packages
+RUN uv pip install --system . langgraph-cli
+
+# Copy .env.example to .env
+# In a production Cloud Run environment, environment variables should be set directly
+# in the service configuration rather than relying on .env files for secrets.
+COPY .env.example .env
+
+# Cloud Run sets the PORT environment variable, so we don't need to EXPOSE it here,
+# but it's good practice for documenting which port the application intends to use.
+# The actual port binding will be handled by the CMD.
+EXPOSE 8080
+
+# Define the command to run the application
+# We use sh -c to allow for environment variable expansion for $PORT.
+# Cloud Run will set the PORT environment variable.
+# The --allow-blocking flag was present in the original README command.
+# --config langgraph.json explicitly points to the config.
+CMD ["sh", "-c", "uvx langgraph dev --host 0.0.0.0 --port ${PORT:-8080} --config langgraph.json --allow-blocking"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,46 @@
+steps:
+  # Build the Docker image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA', '.']
+    id: Build
+
+  # Push the Docker image to Artifact Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA']
+    id: Push
+
+  # Deploy to Cloud Run
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'multi-modal-researcher' # Name of the Cloud Run service
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA'
+      - '--region=us-central1' # Specify your desired region
+      - '--platform=managed'
+      - '--allow-unauthenticated' # Allows public access; change if not desired
+      - '--port=8080' # The port your application listens on, matching Dockerfile's PORT or CMD default
+      - '--set-env-vars=GEMINI_API_KEY=$$GEMINI_API_KEY' # Set environment variables
+      # Add other environment variables as needed, e.g., --set-env-vars=KEY1=VALUE1,KEY2=VALUE2
+      # Cloud Run automatically sets the PORT environment variable for your container
+    id: Deploy
+    secretEnv: ['GEMINI_API_KEY']
+
+# Configuration for GEMINI_API_KEY secret from Secret Manager
+availableSecrets:
+  secretManager:
+  - versionName: projects/$PROJECT_ID/secrets/GEMINI_API_KEY/versions/latest
+    env: 'GEMINI_API_KEY' # This makes it available as $$GEMINI_API_KEY
+
+# Store images in Artifact Registry
+images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA'
+
+# Substitutions (can be overridden at build time)
+substitutions:
+  _REGION: 'us-central1'
+
+# Options
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This commit introduces:
- A Dockerfile to containerize the multi-modal researcher application.
- A cloudbuild.yaml file to automate the build and deployment of the container to Google Cloud Run.

Includes setup for Python 3.11, uv package manager, and running the LangGraph server. The Cloud Build configuration handles pushing to Artifact Registry and deploying to Cloud Run, with GEMINI_API_KEY managed via Secret Manager.