### PR TITLE
Fix: Correct PATH for uv installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
The previous commit had an incorrect PATH environment variable set for the uv installation, causing the `uv` command to be not found in subsequent RUN steps.

This commit corrects the PATH to `/root/.local/bin` as specified by the uv installation script.