### PR TITLE
Fix: Explicitly source executable in Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,5 @@ EXPOSE 8080
 # Cloud Run will set the PORT environment variable.
 # The --allow-blocking flag was present in the original README command.
 # --config langgraph.json explicitly points to the config.
-CMD ["sh", "-c", "uvx langgraph dev --host 0.0.0.0 --port ${PORT:-8080} --config langgraph.json --allow-blocking"]
+# Explicitly specify that 'langgraph' executable comes from 'langgraph-cli' package for uvx.
+CMD ["sh", "-c", "uvx --from langgraph-cli langgraph dev --host 0.0.0.0 --port ${PORT:-8080} --config langgraph.json --allow-blocking"]


### PR DESCRIPTION
Updated the Dockerfile CMD to use `uvx --from langgraph-cli langgraph dev ...`. This explicitly tells `uvx` to use the `langgraph` executable provided by the `langgraph-cli` package, addressing the "Package `langgraph` does not provide any executables" error encountered in Cloud Run.