### PR TITLE
Feat: Add Streamlit frontend for API interaction

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,9 +21,12 @@ steps:
       - '--platform=managed'
       - '--allow-unauthenticated' # Allows public access; change if not desired
       - '--port=8080' # The port your application listens on, matching Dockerfile's PORT or CMD default
-      - '--set-env-vars=GEMINI_API_KEY=$$GEMINI_API_KEY' # Set environment variables
+      - '--set-env-vars=GEMINI_API_KEY=$$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME' # Set environment variables
       # Add other environment variables as needed, e.g., --set-env-vars=KEY1=VALUE1,KEY2=VALUE2
       # Cloud Run automatically sets the PORT environment variable for your container
+      # Note: The Cloud Run service account (default: [PROJECT_NUMBER]-compute@developer.gserviceaccount.com or a user-specified one)
+      # will need 'Storage Object Creator' role on the GCS bucket specified by _GCS_BUCKET_NAME,
+      # and 'Service Account Token Creator' role on itself (or appropriate permissions) to generate signed URLs.
     id: Deploy
     secretEnv: ['GEMINI_API_KEY']
 
@@ -32,6 +35,8 @@ availableSecrets:
   secretManager:
   - versionName: projects/$PROJECT_ID/secrets/GEMINI_API_KEY/versions/latest
     env: 'GEMINI_API_KEY' # This makes it available as $$GEMINI_API_KEY
+  # User needs to define _GCS_BUCKET_NAME as a substitution variable,
+  # e.g., --substitutions=_GCS_BUCKET_NAME=your-bucket-name when running gcloud builds submit
 
 # Store images in Artifact Registry
 images:

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,109 @@
+import streamlit as st
+import requests
+import os
+
+# Try to get the API base URL from an environment variable, otherwise use a default or ask.
+# For the invoke endpoint, it's typically /<graph_id>/invoke
+# The graph_id is 'research_agent' from langgraph.json
+API_INVOKE_URL_DEFAULT = "" # User will need to provide this if not set via env
+API_INVOKE_URL = os.getenv("API_INVOKE_URL", API_INVOKE_URL_DEFAULT)
+
+st.set_page_config(layout="wide")
+st.title("📚 Multi-Modal Researcher AI")
+
+st.sidebar.header("API Configuration")
+api_url_input = st.sidebar.text_input(
+    "Cloud Run API Invoke URL (e.g., https://<service-url>/research_agent/invoke)",
+    value=API_INVOKE_URL
+)
+
+st.sidebar.markdown("""
+This Streamlit app calls a backend API (deployed on Cloud Run) that uses LangGraph and Gemini
+to perform research, synthesize information, and generate a podcast.
+""")
+
+st.header("Research Input")
+topic = st.text_input("Enter the research topic:", placeholder="e.g., The future of AI in education")
+video_url = st.text_input("Optional: Enter a YouTube URL for video analysis:", placeholder="e.g., https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+# Configuration section (optional, could be expanded)
+# st.subheader("Advanced Configuration (Optional)")
+# search_model_override = st.text_input("Override Search Model (e.g., gemini-1.5-pro)", "")
+# tts_model_override = st.text_input("Override TTS Model (e.g., gemini-1.5-flash-tts-preview)", "")
+
+
+if st.button("🚀 Start Research & Generate Podcast"):
+    if not api_url_input:
+        st.error("Please provide the API Invoke URL in the sidebar.")
+    elif not topic:
+        st.error("Please enter a research topic.")
+    else:
+        payload = {
+            "input": {
+                "topic": topic
+            },
+            "config": {}, # Initialize empty config
+            # "kwargs": {} # Usually not needed for basic invoke
+        }
+        if video_url:
+            payload["input"]["video_url"] = video_url
+
+        # Example of adding runtime configuration if we had more inputs for it
+        # configurable_config = {}
+        # if search_model_override:
+        #     configurable_config["search_model"] = search_model_override
+        # if tts_model_override:
+        #     configurable_config["tts_model"] = tts_model_override
+        # if configurable_config:
+        #     payload["config"]["configurable"] = configurable_config
+
+        try:
+            with st.spinner("🔬 Performing research, synthesizing report, and generating podcast... This may take a minute or two."):
+                response = requests.post(api_url_input, json=payload, timeout=300) # 5 min timeout
+
+            st.subheader("📈 API Response")
+            if response.status_code == 200:
+                response_data = response.json()
+
+                # The actual output from the graph is usually under an "output" key
+                # And intermediate steps might be under "messages"
+                output_data = response_data.get("output")
+
+                if output_data:
+                    st.balloons()
+                    st.success("Research and podcast generation complete!")
+
+                    col1, col2 = st.columns(2)
+
+                    with col1:
+                        st.subheader("📝 Research Report")
+                        st.markdown(output_data.get("report", "No report generated."))
+
+                    with col2:
+                        st.subheader("💬 Podcast Script")
+                        st.text_area("Script", value=output_data.get("podcast_script", "No script generated."), height=300)
+
+                        st.subheader("🎙️ Podcast Audio")
+                        podcast_audio_url = output_data.get("podcast_url")
+                        if podcast_audio_url:
+                            st.audio(podcast_audio_url, format="audio/wav")
+                        else:
+                            st.warning("No podcast audio URL found in the response.")
+                else:
+                    st.error("Successful API call, but no 'output' data found in the response.")
+                    st.json(response_data) # Show full response for debugging
+
+            else:
+                st.error(f"API call failed with status code: {response.status_code}")
+                try:
+                    st.json(response.json()) # Show error response if JSON
+                except ValueError:
+                    st.text(response.text) # Show raw text if not JSON
+
+        except requests.exceptions.RequestException as e:
+            st.error(f"An error occurred while calling the API: {e}")
+        except Exception as e:
+            st.error(f"An unexpected error occurred: {e}")
+
+st.sidebar.markdown("---")
+st.sidebar.info("Ensure the backend API is deployed and the URL is correctly entered.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "fastapi",
     "google-genai",
     "rich",
+    "google-cloud-storage>=2.0.0", # Added for GCS operations
+    "streamlit>=1.30.0", # Added for frontend UI
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,11 @@ langchain>=0.3.19
 langchain-google-genai
 python-dotenv>=1.0.1
 langgraph-sdk>=0.1.57
-langgraph-api # Explicitly listed, also a project dependency
+langgraph-api
 fastapi
 google-genai
 rich
-# Ensure langgraph-cli[inmem] is installed, which should bring its necessary dependencies.
-# The pyproject.toml lists langgraph-cli[inmem]>=0.1.71 in dev dependency group.
-# For the main app, we need the project's own code, which is handled by COPY src.
-# Here we list explicit packages that were in pyproject.toml's main dependencies
-# and add langgraph-cli[inmem] for the runtime server.
+google-cloud-storage>=2.0.0
+streamlit>=1.30.0 # Added for frontend UI
+# Ensure langgraph-cli[inmem] is installed for the backend server.
 langgraph-cli[inmem]>=0.1.71

--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -92,13 +92,13 @@ def create_podcast_node(state: ResearchState, config: RunnableConfig) -> dict:
     safe_topic = "".join(c for c in topic if c.isalnum() or c in (' ', '-', '_')).rstrip()
     filename = f"research_podcast_{safe_topic.replace(' ', '_')}.wav"
     
-    podcast_script, podcast_filename = create_podcast_discussion(
+    podcast_script, podcast_url = create_podcast_discussion(
         topic, search_text, video_text, search_sources_text, video_url, filename, configuration
     )
     
     return {
         "podcast_script": podcast_script,
-        "podcast_filename": podcast_filename
+        "podcast_url": podcast_url # Changed from podcast_filename
     }
 
 

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -13,7 +13,7 @@ class ResearchStateOutput(TypedDict):
     # Final outputs
     report: Optional[str]
     podcast_script: Optional[str]
-    podcast_filename: Optional[str]
+    podcast_url: Optional[str] # Changed from podcast_filename
 
 class ResearchState(TypedDict):
     """State for the research and podcast generation workflow"""
@@ -30,4 +30,4 @@ class ResearchState(TypedDict):
     report: Optional[str]
     synthesis_text: Optional[str]
     podcast_script: Optional[str]
-    podcast_filename: Optional[str]
+    podcast_url: Optional[str] # Changed from podcast_filename


### PR DESCRIPTION
This commit introduces a basic Streamlit frontend (`frontend.py`) to interact with the deployed multi-modal researcher API.

Changes include:
- Added `streamlit` to project dependencies (`pyproject.toml` and `requirements.txt`).
- Created `frontend.py` with UI elements for inputting research topic and video URL.
- The frontend calls the specified Cloud Run API invoke URL.
- Displays the research report, podcast script, and an audio player for the podcast URL.
- Updated user instructions on how to run the Streamlit app locally.