### PR TITLE
Feat: Deploy Streamlit frontend as separate Cloud Run service

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,29 @@
+# Use an official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Install uv (consistent with the backend Dockerfile)
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy requirements.txt and frontend.py
+COPY requirements.txt ./
+COPY frontend.py ./
+# Note: If frontend.py had other local dependencies (e.g., image assets in another folder),
+# those would need to be copied too. For now, it's self-contained with requirements.
+
+# Install dependencies using uv
+RUN uv pip install --system -r requirements.txt
+
+# Expose the port Streamlit will run on (Cloud Run sets PORT env var)
+EXPOSE 8080
+
+# Define the command to run the Streamlit application
+# Cloud Run will set the PORT environment variable.
+# --server.headless true is recommended for running in a container.
+# --server.enableCORS false can sometimes be useful, though might not be strictly necessary here.
+# --server.address 0.0.0.0 makes it listen on all available network interfaces.
+CMD ["sh", "-c", "streamlit run frontend.py --server.port ${PORT:-8501} --server.headless true --server.enableCORS false --server.address 0.0.0.0"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,46 +1,83 @@
 steps:
-  # Build the Docker image
+  # --- API Backend Service ---
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA', '.']
-    id: Build
+    args: [
+        'build',
+        '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA',
+        '-f', 'Dockerfile', # Specify the Dockerfile for the API
+        '.'
+      ]
+    id: 'Build API Backend'
 
-  # Push the Docker image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA']
-    id: Push
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA']
+    id: 'Push API Backend'
+    waitFor: ['Build API Backend']
 
-  # Deploy to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
       - 'run'
       - 'deploy'
-      - 'multi-modal-researcher' # Name of the Cloud Run service
-      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA'
-      - '--region=us-central1' # Specify your desired region
+      - 'multi-modal-researcher-api' # API Service Name
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA'
+      - '--region=us-central1'
       - '--platform=managed'
-      - '--allow-unauthenticated' # Allows public access; change if not desired
-      - '--port=8080' # The port your application listens on, matching Dockerfile's PORT or CMD default
-      - '--set-env-vars=GEMINI_API_KEY=$$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME' # Set environment variables
-      # Add other environment variables as needed, e.g., --set-env-vars=KEY1=VALUE1,KEY2=VALUE2
-      # Cloud Run automatically sets the PORT environment variable for your container
-      # Note: The Cloud Run service account (default: [PROJECT_NUMBER]-compute@developer.gserviceaccount.com or a user-specified one)
-      # will need 'Storage Object Creator' role on the GCS bucket specified by _GCS_BUCKET_NAME,
-      # and 'Service Account Token Creator' role on itself (or appropriate permissions) to generate signed URLs.
-    id: Deploy
+      - '--allow-unauthenticated'
+      - '--port=8080'
+      - '--set-env-vars=GEMINI_API_KEY=$$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME'
+      # Note: API Service account needs GCS write and Service Account Token Creator roles.
+    id: 'Deploy API Backend'
     secretEnv: ['GEMINI_API_KEY']
+    waitFor: ['Push API Backend']
 
-# Configuration for GEMINI_API_KEY secret from Secret Manager
+  # --- Streamlit Frontend Service ---
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+        'build',
+        '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-frontend:$COMMIT_SHA',
+        '-f', 'Dockerfile.frontend', # Specify the Dockerfile for the Frontend
+        '.'
+      ]
+    id: 'Build Frontend'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-frontend:$COMMIT_SHA']
+    id: 'Push Frontend'
+    waitFor: ['Build Frontend']
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'multi-modal-researcher-frontend' # Frontend Service Name
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-frontend:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--platform=managed'
+      - '--allow-unauthenticated'
+      - '--port=8080' # Cloud Run expects the app to listen on PORT (default 8080), Streamlit CMD uses ${PORT:-8501}
+      - '--set-env-vars=API_INVOKE_URL=$_API_INVOKE_URL'
+      # Note: _API_INVOKE_URL needs to be the full invoke URL of the API service,
+      # e.g., https://multi-modal-researcher-api-[hash]-uc.a.run.app/research_agent/invoke
+      # This will be passed as a substitution variable by the user.
+    id: 'Deploy Frontend'
+    waitFor: ['Push Frontend', 'Deploy API Backend'] # Deploy frontend after API is deployed (good practice, though URL is external)
+
+# Configuration for secrets and substitutions
 availableSecrets:
   secretManager:
   - versionName: projects/$PROJECT_ID/secrets/GEMINI_API_KEY/versions/latest
-    env: 'GEMINI_API_KEY' # This makes it available as $$GEMINI_API_KEY
-  # User needs to define _GCS_BUCKET_NAME as a substitution variable,
-  # e.g., --substitutions=_GCS_BUCKET_NAME=your-bucket-name when running gcloud builds submit
+    env: 'GEMINI_API_KEY'
+
+# User needs to define these substitution variables when running `gcloud builds submit`:
+# _GCS_BUCKET_NAME for the API backend (e.g., your-gcs-bucket)
+# _API_INVOKE_URL for the Frontend (e.g., https://api-service-url/research_agent/invoke)
 
 # Store images in Artifact Registry
 images:
-  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/multi-modal-researcher:$COMMIT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-frontend:$COMMIT_SHA'
 
 # Substitutions (can be overridden at build time)
 substitutions:


### PR DESCRIPTION
This commit enables the deployment of the Streamlit frontend as a distinct Cloud Run service, alongside the existing API backend service.

Changes include:
- Added `Dockerfile.frontend` to package the Streamlit application.
- Modified `cloudbuild.yaml` to build and deploy two services:
    - `multi-modal-researcher-api` (API backend using `Dockerfile`)
    - `multi-modal-researcher-frontend` (Streamlit UI using `Dockerfile.frontend`)
- The frontend service is configured via an `_API_INVOKE_URL` substitution variable in `cloudbuild.yaml` to point to the API backend.
- User instructions have been updated to reflect the new two-service deployment process and required substitution variables.