### PR TITLE
Add debug logging for API key and Streamlit frontend

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -38,6 +38,11 @@ if st.button("🚀 Start Research & Generate Podcast"):
     elif not topic:
         st.error("Please enter a research topic.")
     else:
+        # --- DEBUG INFO ---
+        st.sidebar.subheader("Debug Info (Frontend)")
+        st.sidebar.text(f"Attempting API call to: {api_url_input}")
+        # --- END DEBUG INFO ---
+
         payload = {
             "input": {
                 "topic": topic
@@ -57,11 +62,28 @@ if st.button("🚀 Start Research & Generate Podcast"):
         # if configurable_config:
         #     payload["config"]["configurable"] = configurable_config
 
+        # --- DEBUG INFO ---
+        st.sidebar.write("Payload being sent:")
+        st.sidebar.json(payload)
+        # --- END DEBUG INFO ---
+
         try:
             with st.spinner("🔬 Performing research, synthesizing report, and generating podcast... This may take a minute or two."):
                 response = requests.post(api_url_input, json=payload, timeout=300) # 5 min timeout
 
             st.subheader("📈 API Response")
+
+            # --- DEBUG INFO ---
+            st.sidebar.subheader("Debug Info (API Response)")
+            st.sidebar.text(f"Status Code: {response.status_code}")
+            try:
+                st.sidebar.write("Full API Response JSON:")
+                st.sidebar.json(response.json())
+            except ValueError:
+                st.sidebar.write("Full API Response Text (not JSON):")
+                st.sidebar.text(response.text)
+            # --- END DEBUG INFO ---
+
             if response.status_code == 200:
                 response_data = response.json()
 

--- a/src/agent/utils.py
+++ b/src/agent/utils.py
@@ -10,7 +10,18 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Initialize client
-genai_client = Client(api_key=os.getenv("GEMINI_API_KEY"))
+gemini_api_key_value = os.getenv("GEMINI_API_KEY")
+
+# !!! WARNING: DEBUGGING CODE - REMOVE AFTER TESTING !!!
+# This will print the API key to your Cloud Run logs.
+# Ensure logs are private and remove this line once you've verified the key.
+if gemini_api_key_value:
+    print(f"DEBUG: GEMINI_API_KEY loaded. Length: {len(gemini_api_key_value)}, First 5 chars: {gemini_api_key_value[:5]}", flush=True)
+else:
+    print("DEBUG: GEMINI_API_KEY IS NOT SET or is empty!", flush=True)
+# !!! END OF DEBUGGING CODE !!!
+
+genai_client = Client(api_key=gemini_api_key_value)
 
 
 def display_gemini_response(response):


### PR DESCRIPTION
This commit includes:
- A temporary debug print in `src/agent/utils.py` to log information about the `GEMINI_API_KEY` (length and first 5 characters) to the Cloud Run logs of the API service. This is for diagnosing API key issues and MUST be removed after testing due to security concerns.
- Additional debug information in the Streamlit UI (`frontend.py`) to display the API URL being called, the request payload, and the full API response details (status code and content) in the sidebar. This helps in troubleshooting frontend-to-backend communication.