### PR TITLE
Re-add detailed API key logging for further diagnosis

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,6 +30,19 @@ steps:
     id: 'Deploy API Backend'
     secretEnv: ['GEMINI_API_KEY']
     waitFor: ['Push API Backend']
+    entrypoint: 'bash' # Changed to bash to allow multiple commands
+    args:
+      - '-c'
+      - |
+        echo "DEBUG (cloudbuild.yaml): GEMINI_API_KEY in build step env: First 5 chars: ${GEMINI_API_KEY:0:5}, Length: ${#GEMINI_API_KEY}"
+        gcloud run deploy multi-modal-researcher-api \
+          --image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA \
+          --region=us-central1 \
+          --platform=managed \
+          --allow-unauthenticated \
+          --port=8080 \
+          --set-env-vars=GEMINI_API_KEY=$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME \
+          # Note: API Service account needs GCS write and Service Account Token Creator roles.
 
   # --- Streamlit Frontend Service ---
   - name: 'gcr.io/cloud-builders/docker'

--- a/src/agent/utils.py
+++ b/src/agent/utils.py
@@ -11,6 +11,14 @@ load_dotenv()
 
 # Initialize client
 gemini_api_key_value = os.getenv("GEMINI_API_KEY")
+
+# !!! WARNING: DEBUGGING CODE - RE-ADDED - REMOVE AFTER TESTING !!!
+if gemini_api_key_value:
+    print(f"DEBUG (utils.py): GEMINI_API_KEY loaded. Length: {len(gemini_api_key_value)}, First 5 chars: {gemini_api_key_value[:5]}", flush=True)
+else:
+    print("DEBUG (utils.py): GEMINI_API_KEY IS NOT SET or is empty!", flush=True)
+# !!! END OF DEBUGGING CODE !!!
+
 genai_client = Client(api_key=gemini_api_key_value)
 
 


### PR DESCRIPTION
This commit re-adds debugging code to help diagnose the persistent 'API key not valid' issue:

1.  In `src/agent/utils.py`: Prints the length and first 5 characters of the GEMINI_API_KEY received by the Python application in Cloud Run.
2.  In `cloudbuild.yaml`: Modified the 'Deploy API Backend' step to use `bash -c` and added an `echo` command to print the length and first 5 characters of the GEMINI_API_KEY as seen by the Cloud Build execution step (from `secretEnv`).

This will allow comparison of the key's state at the build step vs. in the running container.

CRITICAL SECURITY NOTE: These logging statements expose parts of the API key and MUST be removed once debugging is complete, followed by a new deployment.