### PR TITLE
Fix: Correct bash entrypoint and var expansion in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,34 +15,27 @@ steps:
     waitFor: ['Build API Backend']
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
-    args:
-      - 'run'
-      - 'deploy'
-      - 'multi-modal-researcher-api' # API Service Name
-      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA'
-      - '--region=us-central1'
-      - '--platform=managed'
-      - '--allow-unauthenticated'
-      - '--port=8080'
-      - '--set-env-vars=GEMINI_API_KEY=$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME' # Changed $$ to $ for GEMINI_API_KEY
-      # Note: API Service account needs GCS write and Service Account Token Creator roles.
     id: 'Deploy API Backend'
-    secretEnv: ['GEMINI_API_KEY']
+    secretEnv: ['GEMINI_API_KEY'] # Makes GEMINI_API_KEY available to the bash script
     waitFor: ['Push API Backend']
-    entrypoint: 'bash' # Changed to bash to allow multiple commands
+    entrypoint: 'bash'
     args:
       - '-c'
       - |
-        echo "DEBUG (cloudbuild.yaml): GEMINI_API_KEY in build step env: First 5 chars: ${GEMINI_API_KEY:0:5}, Length: ${#GEMINI_API_KEY}"
+        # Echo the value of GEMINI_API_KEY available in this bash environment
+        echo "DEBUG (cloudbuild.yaml): GEMINI_API_KEY from env. First 5: ${GEMINI_API_KEY:0:5}, Length: ${#GEMINI_API_KEY}"
+
+        # Construct the --set-env-vars string.
+        # ${GEMINI_API_KEY} will be expanded by this bash shell from its environment.
+        # $_GCS_BUCKET_NAME and $_REGION will be substituted by Cloud Build *before* this script runs.
         gcloud run deploy multi-modal-researcher-api \
           --image=us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-deploy/multi-modal-researcher-api:$COMMIT_SHA \
-          --region=us-central1 \
+          --region=$_REGION \
           --platform=managed \
           --allow-unauthenticated \
           --port=8080 \
-          --set-env-vars=GEMINI_API_KEY=$GEMINI_API_KEY,GCS_BUCKET_NAME=$_GCS_BUCKET_NAME \
-          # Note: API Service account needs GCS write and Service Account Token Creator roles.
+          --set-env-vars="GEMINI_API_KEY=${GEMINI_API_KEY},GCS_BUCKET_NAME=$_GCS_BUCKET_NAME"
+        # Note: API Service account needs GCS write and Service Account Token Creator roles.
 
   # --- Streamlit Frontend Service ---
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
This commit corrects the 'Deploy API Backend' step in `cloudbuild.yaml` to properly use a single `entrypoint: bash` and ensures that the script correctly handles shell expansion for the `GEMINI_API_KEY` (from `secretEnv`) and Cloud Build substitutions like `_GCS_BUCKET_NAME` and `_REGION`.

This addresses the "invalid value for 'build.substitutions': key in the template 'GEMINI_API_KEY' is not a valid built-in substitution" error.

Debug code (echo in cloudbuild.yaml and print in utils.py) for GEMINI_API_KEY is still present for one more verification round and MUST be removed after testing.