### PR TITLE
Add conditional podcast creation to LangGraph

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -112,6 +112,12 @@ def should_analyze_video(state: ResearchState) -> str:
     else:
         return "create_report"
 
+def should_create_podcast(state: ResearchState) -> str:
+    """Conditional edge to determine if podcast creation should be performed"""
+    if state.get("create_podcast", False): # Default to False if not set, though it should be
+        return "create_podcast"
+    else:
+        return END
 
 def create_research_graph() -> StateGraph:
     """Create and return the research workflow graph"""
@@ -141,7 +147,16 @@ def create_research_graph() -> StateGraph:
         }
     )
     graph.add_edge("analyze_video", "create_report")
-    graph.add_edge("create_report", "create_podcast")
+
+    # Conditional edge for podcast creation
+    graph.add_conditional_edges(
+        "create_report",
+        should_create_podcast,
+        {
+            "create_podcast": "create_podcast",
+            END: END # If no podcast, end here
+        }
+    )
     graph.add_edge("create_podcast", END)
     
     return graph

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -2,32 +2,33 @@ from typing_extensions import TypedDict
 from typing import Optional
 
 class ResearchStateInput(TypedDict):
-    """State for the research and podcast generation workflow"""
+    """Input state for the research and podcast generation workflow"""
     # Input fields
     topic: str
     video_url: Optional[str]
+    create_podcast: bool # User preference to create a podcast or not
 
 class ResearchStateOutput(TypedDict):
-    """State for the research and podcast generation workflow"""
-
+    """Output state for the research and podcast generation workflow"""
     # Final outputs
-    report: Optional[str]
-    podcast_script: Optional[str]
-    podcast_url: Optional[str] # Changed from podcast_filename
+    report: Optional[str] # URL to the research report
+    podcast_script: Optional[str] # Text script of the podcast
+    podcast_url: Optional[str] # URL to the podcast audio file
 
 class ResearchState(TypedDict):
-    """State for the research and podcast generation workflow"""
-    # Input fields
+    """Full state for the research and podcast generation workflow"""
+    # Input fields (mirrored from ResearchStateInput for internal use)
     topic: str
     video_url: Optional[str]
+    create_podcast: bool
     
     # Intermediate results
     search_text: Optional[str]
     search_sources_text: Optional[str]
     video_text: Optional[str]
+    synthesis_text: Optional[str] # Text used for report/podcast generation
     
-    # Final outputs
+    # Final outputs (mirrored from ResearchStateOutput)
     report: Optional[str]
-    synthesis_text: Optional[str]
     podcast_script: Optional[str]
-    podcast_url: Optional[str] # Changed from podcast_filename
+    podcast_url: Optional[str]


### PR DESCRIPTION
- Added `create_podcast: bool` to `ResearchStateInput` and `ResearchState` to control podcast generation.
- Modified `create_research_graph` to include a conditional edge after report creation.
- If `create_podcast` is true, the graph proceeds to generate the podcast.
- If `create_podcast` is false, the graph ends after report generation.
- Ensured output state correctly handles optional podcast fields.