### PR TITLE
fix: Update tool definition for lead identification node

### DIFF
--- a/src/agent/graph.py
+++ b/src/agent/graph.py
@@ -135,12 +135,12 @@ def identify_leads_node(state: ResearchState, config: RunnableConfig) -> dict:
     response = genai_client.models.generate_content(
         model=configuration.lead_identification_model, # Use dedicated model
         contents=prompt,
-        config={
-            "tools": GOOGLE_SEARCH_TOOL,
-            "temperature": configuration.lead_identification_temperature, # Use dedicated temp
+        tools=[types.Tool(google_search_retrieval=types.GoogleSearchRetrieval())], # Updated tool definition
+        generation_config=types.GenerationConfig(
+            temperature=configuration.lead_identification_temperature, # Use dedicated temp
             # Consider requesting JSON output directly if model/API supports reliably:
-            # "response_mime_type": "application/json",
-        },
+            # response_mime_type="application/json", # This should be part of GenerationConfig
+        )
     )
 
     identified_leads = parse_leads_from_gemini_response(response)


### PR DESCRIPTION
Corrects the Google Search tool configuration in the `identify_leads_node` to use `google_search_retrieval` as required by the specified Gemini model. The previous `google_search` tool definition was causing an API error.

The `generate_content` call was updated to pass tools as a list of `Tool` objects and temperature via `GenerationConfig`.